### PR TITLE
Support custom order and separator

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ You must enable write permission in github.com/user/repo/settings/actions -> Wor
 | `dry-run`      | Run without upload. will be available in the console output of the action.                                                      | No           | `checksum.txt`   |
 | `bun-version`  | The version of Bun to use.                                                                                                      | No           | `latest`         |
 | `reverse-order`| If set to true the order of checksum and filename in the output file will be reversed.                                          | No           | `false`          |
+| `separator`    | Separator between filename and checksum. If you want to use special chars you can pass something like `${{ fromJSON('"\n"') }}` | No           | `\t`             |
 
 ## Example checksum.txt
 
@@ -38,7 +39,7 @@ a.txt	ca978112ca1bbdcafac231b39a23dc4da786eff8147c4e72b9807785afee48bb
 b.txt	0263829989b6fd954f72baaf2fc64bc2e2f01d692d4de72986ea808f6e99813f
 ```
 
-Each line separated by tab. (`\t`)
+Each line separated by the specified separator. (By default `\t`)
 
 ## Full example
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ You must enable write permission in github.com/user/repo/settings/actions -> Wor
 | `file-name`    | The name of the checksum file to generate.                                                                                      | No           | `checksum.txt`   |
 | `dry-run`      | Run without upload. will be available in the console output of the action.                                                      | No           | `checksum.txt`   |
 | `bun-version`  | The version of Bun to use.                                                                                                      | No           | `latest`         |
+| `reverse-order`| If set to true the order of checksum and filename in the output file will be reversed.                                          | No           | `false`          |
 
 ## Example checksum.txt
 

--- a/action.yml
+++ b/action.yml
@@ -65,3 +65,4 @@ runs:
         INPUT_REPO: ${{ inputs.repo }}
         INPUT_DRY_RUN: ${{ inputs.dry-run }}
         INPUT_REVERSE_ORDER: ${{ inputs.reverse-order }}
+        INPUT_SEPARATOR: ${{ inputs.separator }}

--- a/action.yml
+++ b/action.yml
@@ -37,6 +37,10 @@ inputs:
     description: "Create checksum without upload. will be available in the output of the action run"
     required: false
     default: 'false'
+  reverse-order:
+    description: "Reverse the order of the filename and checksum"
+    required: false
+    default: 'false'
 
 runs:
   using: "composite"
@@ -57,3 +61,4 @@ runs:
         INPUT_PRE_RELEASE: ${{ inputs.pre-release }}
         INPUT_REPO: ${{ inputs.repo }}
         INPUT_DRY_RUN: ${{ inputs.dry-run }}
+        INPUT_REVERSE_ORDER: ${{ inputs.reverse-order }}

--- a/action.yml
+++ b/action.yml
@@ -41,6 +41,9 @@ inputs:
     description: "Reverse the order of the filename and checksum"
     required: false
     default: 'false'
+  separator:
+    description: "Separator between filename and checksum"
+    required: false
 
 runs:
   using: "composite"

--- a/index.ts
+++ b/index.ts
@@ -112,12 +112,14 @@ console.log(`Repo: ${process.env.INPUT_REPO}`);
 console.log(`Tag Input: ${process.env.INPUT_TAG}`);
 console.log(`Patterns Input: ${process.env.INPUT_PATTERNS}`);
 console.log(`Dry Run: ${process.env.INPUT_DRY_RUN}`);
+console.log(`Reverse Order: ${process.env.INPUT_REVERSE_ORDER}`);
 
 // Constants
 const checkSumPath = process.env.INPUT_FILE_NAME!; // checksum.txt by default
 const minSizeImmediateUpload = 1000 * 1000 * 500; // 500MB
 const isDryRun = process.env.INPUT_DRY_RUN === 'true'
 const isPreRelease = process.env.INPUT_PRE_RELEASE === "true";
+const isReverseOrder = process.env.INPUT_REVERSE_ORDER === "true";
 
 // Algorithm
 const hashAlgorithm = process.env.INPUT_ALGORITHM || "sha256";
@@ -175,7 +177,11 @@ for (const asset of releases.assets) {
 
   const checksum = await generateChecksum(asset.name);
   await unlink(asset.name); // Remove file immediately after get checksum
-  await appendFile(checkSumPath, `${asset.name}\t${checksum}\n`);
+  if (isReverseOrder) {
+    await appendFile(checkSumPath, `${checksum}\t${asset.name}\n`);
+  } else {
+    await appendFile(checkSumPath, `${asset.name}\t${checksum}\n`);
+  }
 
   if (asset.size > minSizeImmediateUpload) {
     console.log(`Uploading immdiately due to large file: ${asset.name}`);

--- a/index.ts
+++ b/index.ts
@@ -120,6 +120,7 @@ const minSizeImmediateUpload = 1000 * 1000 * 500; // 500MB
 const isDryRun = process.env.INPUT_DRY_RUN === 'true'
 const isPreRelease = process.env.INPUT_PRE_RELEASE === "true";
 const isReverseOrder = process.env.INPUT_REVERSE_ORDER === "true";
+const separator = process.env.INPUT_SEPARATOR || "\t";
 
 // Algorithm
 const hashAlgorithm = process.env.INPUT_ALGORITHM || "sha256";
@@ -178,9 +179,9 @@ for (const asset of releases.assets) {
   const checksum = await generateChecksum(asset.name);
   await unlink(asset.name); // Remove file immediately after get checksum
   if (isReverseOrder) {
-    await appendFile(checkSumPath, `${checksum}\t${asset.name}\n`);
+    await appendFile(checkSumPath, `${checksum}${separator}${asset.name}\n`);
   } else {
-    await appendFile(checkSumPath, `${asset.name}\t${checksum}\n`);
+    await appendFile(checkSumPath, `${asset.name}${separator}${checksum}\n`);
   }
 
   if (asset.size > minSizeImmediateUpload) {


### PR DESCRIPTION
This PR adds option to add custom separator and order to make the output file compatible with tools like `sha256sum`.

If you specify:
```
with:
    reverse-order: true
    separator: ' '
```

You can use `sha256sum` to verify all assets at once with:
```
sha256sum -c checksum.txt
```